### PR TITLE
Fix Float32Array size

### DIFF
--- a/SatelliteSimulator/Rendering/SimulationWebGLRenderer.razor.js
+++ b/SatelliteSimulator/Rendering/SimulationWebGLRenderer.razor.js
@@ -99,7 +99,7 @@ export function init(elem, component) {
 
             const count = Blazor.platform.getArrayLength(suns);
             const stride = bufferInfo.attribs.satellitePosition.stride;
-            const data = new Float32Array(Module.HEAP8.buffer, Blazor.platform.getArrayEntryPtr(suns, 0, stride), count * stride);
+            const data = new Float32Array(Module.HEAP8.buffer, Blazor.platform.getArrayEntryPtr(suns, 0, stride), count * (stride / 4));
 
             twgl.setAttribInfoBufferFromArray(gl, bufferInfo.attribs.position, circleVertices);
             twgl.setAttribInfoBufferFromArray(gl, bufferInfo.attribs.satellitePosition, data);
@@ -111,7 +111,7 @@ export function init(elem, component) {
         renderSatellites(satellites) {
             const count = Blazor.platform.getArrayLength(satellites);
             const stride = bufferInfo.attribs.satellitePosition.stride;
-            const data = new Float32Array(Module.HEAP8.buffer, Blazor.platform.getArrayEntryPtr(satellites, 0, stride), count * stride);
+            const data = new Float32Array(Module.HEAP8.buffer, Blazor.platform.getArrayEntryPtr(satellites, 0, stride), count * (stride / 4));
 
             twgl.setAttribInfoBufferFromArray(gl, bufferInfo.attribs.position, pointVertices);
             twgl.setAttribInfoBufferFromArray(gl, bufferInfo.attribs.satellitePosition, data);


### PR DESCRIPTION
Before that patch, it creates a wrong `Float32Array`, based on the size in bytes (`count * stride`). 

That sounds wrong, since `Float32Array` expect the size in `Float32` (4 bytes). This patch replaces it to `count * (stride / 4)`. The size (in bytes) can be compared using `count * stride === data.byteLength` which will return `true`.

-----

That change improves the performance, on my machine from ~150_000 to ~350_000.